### PR TITLE
[hyorimcho] reservations page 구현

### DIFF
--- a/src/components/Product.tsx
+++ b/src/components/Product.tsx
@@ -26,21 +26,23 @@ const Product = (productData: IProduct) => {
     const productLength =
       cart.filter((item: IProduct) => item.idx === product.idx).length + 1;
 
-    if (productLength <= Number(product.maximumPurchases)) {
-      dispatch(addToCart(product));
-      toast({
-        title: `${product.name} 1개 추가`,
-        description: `장바구니에 ${productLength}개 있습니다`,
-        position: 'top-right',
-        status: 'success',
-        isClosable: true,
-      });
-    } else {
+    const matchedCart = cart.find((item) => item.idx === product.idx);
+
+    if (product.maximumPurchases === (matchedCart?.quantity as number)) {
       toast({
         title: `${product.name} 구매 개수 초과`,
         description: `인 당 ${product.maximumPurchases}개만 구매하실 수 있습니다.`,
         position: 'top-right',
         status: 'error',
+        isClosable: true,
+      });
+    } else {
+      dispatch(addToCart({ ...product, quantity: 1 }));
+      toast({
+        title: `${product.name} 1개 추가`,
+        description: `장바구니에 ${productLength}개 있습니다`,
+        position: 'top-right',
+        status: 'success',
         isClosable: true,
       });
     }

--- a/src/components/ProductList.tsx
+++ b/src/components/ProductList.tsx
@@ -8,6 +8,8 @@ import {
   RangeSliderThumb,
   Stack,
   Text,
+  WrapItem,
+  Button,
 } from '@chakra-ui/react';
 import { getProducts } from '@/store/slices/productSlice';
 import Product from '@/components/Product';
@@ -18,6 +20,7 @@ import {
   getMaxPrice,
 } from '@/lib/utils/productsHelpers';
 import SpaceTag from './SpaceTag';
+import { Link } from 'react-router-dom';
 
 const ProductList = () => {
   const dispatch = useAppDispatch();
@@ -65,6 +68,9 @@ const ProductList = () => {
   return (
     <VStack as="section" bg="blue.100" w="75%" minW="500px" p={4}>
       <Heading>상품 정보</Heading>
+      <Link to="/reservations">
+        <Button colorScheme="telegram">장바구니</Button>
+      </Link>
       <VStack as="section" bg="blue.100" w="100%" p={4}>
         <RangeSlider defaultValue={[0, 100]} onChange={onSlidePrice}>
           <RangeSliderTrack>

--- a/src/components/ReservationList.tsx
+++ b/src/components/ReservationList.tsx
@@ -1,4 +1,4 @@
-import { IProduct } from '@/interface/product';
+import { ICart, IProduct } from '@/interface/product';
 import { RootState, useAppDispatch, useAppSelector } from '@/store';
 import {
   decrementQuantity,
@@ -22,7 +22,7 @@ import {
 } from '@chakra-ui/react';
 
 interface Props {
-  product: IProduct;
+  product: ICart;
 }
 
 const ReservationList = ({ product }: Props) => {
@@ -30,13 +30,10 @@ const ReservationList = ({ product }: Props) => {
   const { cart } = useAppSelector((state) => state);
   const toast = useToast();
 
-  console.log('product', product);
-
   const matchedCart = cart.find((item) => item.idx === product.idx);
 
   const handleClickIncrement = () => {
-    console.log(product.maximumPurchases);
-    if (product.maximumPurchases === matchedCart?.maximumPurchases) {
+    if (product.maximumPurchases === matchedCart?.quantity) {
       toast({
         title: `${product.name} 최대 구매 개수 초과`,
         description: `인 당 ${product.maximumPurchases}개만 구매하실 수 있습니다.`,

--- a/src/components/ReservationList.tsx
+++ b/src/components/ReservationList.tsx
@@ -1,0 +1,143 @@
+import { IProduct } from '@/interface/product';
+import { RootState, useAppDispatch, useAppSelector } from '@/store';
+import {
+  decrementQuantity,
+  incrementQuantity,
+  removeItem,
+} from '@/store/slices/cartSlice';
+import {
+  Badge,
+  Box,
+  Button,
+  ButtonGroup,
+  Card,
+  CardBody,
+  CardFooter,
+  Divider,
+  Heading,
+  Image,
+  Stack,
+  Text,
+  useToast,
+} from '@chakra-ui/react';
+
+interface Props {
+  product: IProduct;
+}
+
+const ReservationList = ({ product }: Props) => {
+  const dispatch = useAppDispatch();
+  const { cart } = useAppSelector((state) => state);
+  const toast = useToast();
+
+  console.log('product', product);
+
+  const matchedCart = cart.find((item) => item.idx === product.idx);
+
+  const handleClickIncrement = () => {
+    console.log(product.maximumPurchases);
+    if (product.maximumPurchases === matchedCart?.maximumPurchases) {
+      toast({
+        title: `${product.name} 최대 구매 개수 초과`,
+        description: `인 당 ${product.maximumPurchases}개만 구매하실 수 있습니다.`,
+        status: 'error',
+        duration: 5000,
+        isClosable: true,
+        position: 'bottom-right',
+      });
+    } else {
+      dispatch(incrementQuantity({ ...product, quantity: 1 }));
+
+      toast({
+        title: `장바구니에 추가되었습니다.`,
+        status: 'success',
+        duration: 5000,
+        isClosable: true,
+        position: 'bottom-right',
+      });
+    }
+  };
+  const handleClickDecrement = () => {
+    if ((matchedCart?.quantity as number) > 1) {
+      dispatch(decrementQuantity({ ...product, quantity: 1 }));
+
+      toast({
+        title: '성공적으로 삭제되었습니다.',
+        status: 'success',
+        duration: 5000,
+        isClosable: true,
+        position: 'bottom-right',
+      });
+    }
+  };
+  const handleClickRemove = () => {
+    dispatch(removeItem(product));
+
+    toast({
+      title: '성공적으로 삭제되었습니다.',
+      status: 'success',
+      duration: 5000,
+      isClosable: true,
+      position: 'bottom-right',
+    });
+  };
+
+  return (
+    <Card
+      maxW="md"
+      key={product.idx}
+      _hover={{
+        shadow: 'md',
+        transitionTimingFunction: 'ease-in-out',
+        transitionDuration: '0.3s',
+      }}
+    >
+      <CardBody>
+        <Image src={product.mainImage} alt={product.name} borderRadius="lg" />
+        <Stack mt="6" spacing="3">
+          <Heading size="md" wordBreak="keep-all">
+            <Text display="inline-block">{product.idx}</Text>. {product.name}
+          </Heading>
+          <Text
+            color="blue.600"
+            fontSize="xl"
+            display="flex"
+            alignItems="center"
+            gap="4"
+          >
+            {product.price.toLocaleString()} 원
+            <Badge p="2" borderRadius="md">
+              {product.spaceCategory}
+            </Badge>
+          </Text>
+        </Stack>
+      </CardBody>
+      <Divider />
+      <CardFooter justifyContent="center">
+        <ButtonGroup spacing="2" display="flex" alignItems="center" gap="1">
+          <Button
+            variant="outline"
+            colorScheme="blue"
+            onClick={handleClickIncrement}
+          >
+            +
+          </Button>
+
+          <Box>{product.quantity}</Box>
+
+          <Button
+            variant="outline"
+            colorScheme="blue"
+            onClick={handleClickDecrement}
+          >
+            -
+          </Button>
+          <Button colorScheme="red" onClick={handleClickRemove}>
+            삭제
+          </Button>
+        </ButtonGroup>
+      </CardFooter>
+    </Card>
+  );
+};
+export default ReservationList;

--- a/src/interface/product.d.ts
+++ b/src/interface/product.d.ts
@@ -7,6 +7,7 @@ export interface IProduct {
   price: number;
   maximumPurchases: number;
   registrationDate: string;
+  quantity?: number;
 }
 
 export interface IProductReducer {

--- a/src/interface/product.d.ts
+++ b/src/interface/product.d.ts
@@ -7,11 +7,14 @@ export interface IProduct {
   price: number;
   maximumPurchases: number;
   registrationDate: string;
-  quantity?: number;
 }
 
 export interface IProductReducer {
   isLoading: boolean;
   error: string | null;
   products: IProduct[];
+}
+
+export interface ICart extends IProduct {
+  quantity?: number;
 }

--- a/src/lib/utils/getTotals.ts
+++ b/src/lib/utils/getTotals.ts
@@ -1,0 +1,11 @@
+import { ICart } from '@/interface/product';
+
+export const getTotal = (cart: ICart[]) => {
+  let totalQuantity = 0;
+  let totalPrice = 0;
+  cart.forEach((item) => {
+    totalQuantity += item.quantity!;
+    totalPrice += item.price * item.quantity!;
+  });
+  return { totalQuantity, totalPrice };
+};

--- a/src/pages/Reservations.tsx
+++ b/src/pages/Reservations.tsx
@@ -1,4 +1,32 @@
+import ReservationList from '@/components/ReservationList';
+import { getTotal } from '@/lib/utils/getTotals';
+import { useAppSelector } from '@/store';
+import { Box, Container, Grid, Heading } from '@chakra-ui/react';
+
 const Reservations = () => {
-  return <div>Reservations</div>;
+  const { cart } = useAppSelector((state) => state);
+  console.log('cart', cart);
+
+  return (
+    <Container as="section" maxW="1280px" padding="10">
+      <Heading mb="8" fontSize="2xl">
+        총 수량 {getTotal(cart).totalQuantity}
+      </Heading>
+      <Grid templateColumns="repeat(auto-fill, minmax(15rem, 1fr))" gap={10}>
+        {cart.length > 0 ? (
+          cart.map((product) => (
+            <ReservationList key={product.idx} product={product} />
+          ))
+        ) : (
+          <Heading fontSize="xl">장바구니가 비었습니다.</Heading>
+        )}
+      </Grid>
+      <Box mt="14">
+        <Heading fontSize="xl">
+          합계 {getTotal(cart).totalPrice.toLocaleString()} 원
+        </Heading>
+      </Box>
+    </Container>
+  );
 };
 export default Reservations;

--- a/src/pages/Reservations.tsx
+++ b/src/pages/Reservations.tsx
@@ -14,8 +14,8 @@ const Reservations = () => {
       </Heading>
       <Grid templateColumns="repeat(auto-fill, minmax(15rem, 1fr))" gap={10}>
         {cart.length > 0 ? (
-          cart.map((product) => (
-            <ReservationList key={product.idx} product={product} />
+          cart.map((product, i) => (
+            <ReservationList key={i} product={product} />
           ))
         ) : (
           <Heading fontSize="xl">장바구니가 비었습니다.</Heading>

--- a/src/store/slices/cartSlice.ts
+++ b/src/store/slices/cartSlice.ts
@@ -1,37 +1,42 @@
-import { IProduct } from '@/interface/product';
+import { ICart } from '@/interface/product';
 import { createSlice } from '@reduxjs/toolkit';
 import type { PayloadAction } from '@reduxjs/toolkit';
 
-const initialState: IProduct[] = [];
+const initialState: ICart[] = [];
 
 const cartSlice = createSlice({
   name: 'cart',
   initialState,
   reducers: {
-    addToCart: (state, action: PayloadAction<IProduct>) => {
+    addToCart: (state, action: PayloadAction<ICart>) => {
       const itemInCart = state.find((item) => item.idx === action.payload.idx);
       if (
         itemInCart &&
         itemInCart.quantity! <= action.payload.maximumPurchases
       ) {
-        itemInCart.quantity! += action.payload.quantity as number;
+        itemInCart.quantity! += action.payload.quantity!;
       } else {
         state.push(action.payload);
       }
     },
-    incrementQuantity: (state, action: PayloadAction<IProduct>) => {
+    incrementQuantity: (state, action: PayloadAction<ICart>) => {
       const itemInCart = state.find((item) => item.idx === action.payload.idx);
-      if (itemInCart && itemInCart.quantity! <= action.payload.maximumPurchases)
-        // itemInCart.length += 1;
-        console.log('itemInCart', itemInCart);
+      if (
+        itemInCart &&
+        itemInCart.quantity! <= action.payload.maximumPurchases
+      ) {
+        itemInCart.quantity! += 1;
+      }
+      // itemInCart.length += 1;
+      console.log('itemInCart', itemInCart);
     },
-    decrementQuantity: (state, action: PayloadAction<IProduct>) => {
+    decrementQuantity: (state, action: PayloadAction<ICart>) => {
       const itemInCart = state.find((item) => item.idx === action.payload.idx);
       if (itemInCart && itemInCart.quantity === 1) {
         itemInCart.quantity = 1;
       } else if (itemInCart) itemInCart.quantity! -= 1;
     },
-    removeItem: (state, action: PayloadAction<IProduct>) => {
+    removeItem: (state, action: PayloadAction<ICart>) => {
       return state.filter((item) => item.idx !== action.payload.idx);
     },
   },

--- a/src/store/slices/cartSlice.ts
+++ b/src/store/slices/cartSlice.ts
@@ -1,5 +1,6 @@
 import { IProduct } from '@/interface/product';
 import { createSlice } from '@reduxjs/toolkit';
+import type { PayloadAction } from '@reduxjs/toolkit';
 
 const initialState: IProduct[] = [];
 
@@ -7,12 +8,36 @@ const cartSlice = createSlice({
   name: 'cart',
   initialState,
   reducers: {
-    addToCart: (state, action) => {
-      return [...state, action.payload];
+    addToCart: (state, action: PayloadAction<IProduct>) => {
+      const itemInCart = state.find((item) => item.idx === action.payload.idx);
+      if (
+        itemInCart &&
+        itemInCart.quantity! <= action.payload.maximumPurchases
+      ) {
+        itemInCart.quantity! += action.payload.quantity as number;
+      } else {
+        state.push(action.payload);
+      }
+    },
+    incrementQuantity: (state, action: PayloadAction<IProduct>) => {
+      const itemInCart = state.find((item) => item.idx === action.payload.idx);
+      if (itemInCart && itemInCart.quantity! <= action.payload.maximumPurchases)
+        // itemInCart.length += 1;
+        console.log('itemInCart', itemInCart);
+    },
+    decrementQuantity: (state, action: PayloadAction<IProduct>) => {
+      const itemInCart = state.find((item) => item.idx === action.payload.idx);
+      if (itemInCart && itemInCart.quantity === 1) {
+        itemInCart.quantity = 1;
+      } else if (itemInCart) itemInCart.quantity! -= 1;
+    },
+    removeItem: (state, action: PayloadAction<IProduct>) => {
+      return state.filter((item) => item.idx !== action.payload.idx);
     },
   },
 });
 
-export const { addToCart } = cartSlice.actions;
+export const { addToCart, incrementQuantity, decrementQuantity, removeItem } =
+  cartSlice.actions;
 
 export default cartSlice.reducer;


### PR DESCRIPTION
## 구현 내용
- [x]  저장한 여행 상품의 리스트 보여주기
- [x]  저장한 여행 상품 삭제
- [x]  여행 상품의 구매 수량 변경
- [x]  장바구니에 있는 여행 상품의 총 결제액 수를 계산하여 표시

## 참고 사항
- 장바구니에 담긴 상품의 개수를 세기 위해 `quantity`라는 속성을 추가해주고 기존 best practice 코드를 일부 수정하였습니다.
- `getTotal` 이라는 함수를 만들어 장바구니에 담긴 물건들의 총 개수와 금액을 셀 수 있게 만들어 주었고 utils 로 분리하였습니다.
- cartSlice 내부에 `incrementQuantity`, `decrementQuantity`, `removeItem`을 만들어 장바구니의 상품 증가, 감소, 삭제를 구현했습니다.
- 상품 추가나 최대 구매 가능 개수를 넘겨 실패시에는 toast를 띄워주었습니다.

## SAMPLE
![2023-03-09](https://user-images.githubusercontent.com/103406196/224035677-19430ccd-7d73-4229-bd93-3cebfb049130.gif)

