### PR TITLE
[Noeyso] reservations page 구현

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.1.0",
       "hasInstallScript": true,
       "dependencies": {
+        "@chakra-ui/icons": "^2.0.17",
         "@chakra-ui/react": "^2.5.1",
         "@craco/craco": "^7.0.0",
         "@emotion/react": "^11.10.6",
@@ -2164,6 +2165,18 @@
       "integrity": "sha512-RpA1X5Ptz8Mt39HSyEIW1wxAz2AXyf9H0JJ5HVx/dBdMZaGMDJ0HyyPBVci0m4RCoJuyG1HHG/DXJaVfUTVAeg==",
       "dependencies": {
         "@chakra-ui/shared-utils": "2.0.5"
+      },
+      "peerDependencies": {
+        "@chakra-ui/system": ">=2.0.0",
+        "react": ">=18"
+      }
+    },
+    "node_modules/@chakra-ui/icons": {
+      "version": "2.0.17",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/icons/-/icons-2.0.17.tgz",
+      "integrity": "sha512-HMJP0WrJgAmFR9+Xh/CBH0nVnGMsJ4ZC8MK6tMgxPKd9/muvn0I4hsicHqdPlLpmB0TlxlhkBAKaVMtOdz6F0w==",
+      "dependencies": {
+        "@chakra-ui/icon": "3.0.16"
       },
       "peerDependencies": {
         "@chakra-ui/system": ">=2.0.0",
@@ -20599,6 +20612,14 @@
       "integrity": "sha512-RpA1X5Ptz8Mt39HSyEIW1wxAz2AXyf9H0JJ5HVx/dBdMZaGMDJ0HyyPBVci0m4RCoJuyG1HHG/DXJaVfUTVAeg==",
       "requires": {
         "@chakra-ui/shared-utils": "2.0.5"
+      }
+    },
+    "@chakra-ui/icons": {
+      "version": "2.0.17",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/icons/-/icons-2.0.17.tgz",
+      "integrity": "sha512-HMJP0WrJgAmFR9+Xh/CBH0nVnGMsJ4ZC8MK6tMgxPKd9/muvn0I4hsicHqdPlLpmB0TlxlhkBAKaVMtOdz6F0w==",
+      "requires": {
+        "@chakra-ui/icon": "3.0.16"
       }
     },
     "@chakra-ui/image": {

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "0.1.0",
   "private": true,
   "dependencies": {
+    "@chakra-ui/icons": "^2.0.17",
     "@chakra-ui/react": "^2.5.1",
     "@craco/craco": "^7.0.0",
     "@emotion/react": "^11.10.6",

--- a/src/components/CartButton.tsx
+++ b/src/components/CartButton.tsx
@@ -1,0 +1,33 @@
+import { Box, Button, HStack } from '@chakra-ui/react';
+import React from 'react';
+import { Link } from 'react-router-dom';
+import { useAppSelector } from '@/store';
+
+const CartButton = () => {
+  const cartList = useAppSelector((state) => state.cart);
+  return (
+    <HStack position="relative" alignSelf="flex-end">
+      {cartList.length && (
+        <Box
+          borderRadius="50"
+          w="5"
+          h="5"
+          backgroundColor="red"
+          position="absolute"
+          top="-2"
+          right="-2"
+          textAlign="center"
+          color="white"
+          zIndex={1}
+        >
+          {cartList.length}
+        </Box>
+      )}
+      <Link to="/reservations">
+        <Button>장바구니</Button>
+      </Link>
+    </HStack>
+  );
+};
+
+export default CartButton;

--- a/src/components/CartItem.tsx
+++ b/src/components/CartItem.tsx
@@ -10,11 +10,13 @@ import {
   Text,
   CardFooter,
   Button,
+  Toast,
 } from '@chakra-ui/react';
 import React from 'react';
 import { IProduct } from '@/interface/product';
 import { useAppDispatch } from '@/store';
 import { onOpen } from '@/store/slices/modalSlice';
+import { deleteCartItem } from '@/store/slices/cartSlice';
 
 type Props = {
   product: IProduct;
@@ -22,6 +24,17 @@ type Props = {
 
 const CartItem = ({ product }: Props) => {
   const dispatch = useAppDispatch();
+
+  const onDeleteCartItem = () => {
+    Toast({
+      title: `장바구니 아이템 삭제`,
+      description: `상품이 삭제되었습니다.`,
+      position: 'top-right',
+      status: 'success',
+      isClosable: true,
+    });
+    dispatch(onOpen(product));
+  };
   return (
     <Card direction={{ base: 'column', sm: 'row' }} w="100%" variant="outline">
       <Image
@@ -52,16 +65,12 @@ const CartItem = ({ product }: Props) => {
             variant="solid"
             colorScheme="blue"
             onClick={() => {
-              alert('준비중');
+              dispatch(deleteCartItem(product.idx));
             }}
           >
             삭제
           </Button>
-          <Button
-            variant="solid"
-            colorScheme="blue"
-            onClick={() => dispatch(onOpen(product))}
-          >
+          <Button variant="solid" colorScheme="blue" onClick={onDeleteCartItem}>
             더 보 기
           </Button>
         </CardFooter>

--- a/src/components/CartItem.tsx
+++ b/src/components/CartItem.tsx
@@ -42,7 +42,7 @@ const CartItem = ({ product }: Props) => {
 
   const onModifyCartItem = (n: number) => {
     const quantity = product.quantity + n;
-    if (quantity < 0) {
+    if (quantity < 1) {
       return;
     } else if (quantity > product.maximumPurchases) {
       toast({

--- a/src/components/CartItem.tsx
+++ b/src/components/CartItem.tsx
@@ -10,23 +10,27 @@ import {
   Text,
   CardFooter,
   Button,
-  Toast,
+  IconButton,
+  HStack,
+  useToast,
 } from '@chakra-ui/react';
 import React from 'react';
-import { IProduct } from '@/interface/product';
 import { useAppDispatch } from '@/store';
 import { onOpen } from '@/store/slices/modalSlice';
-import { deleteCartItem } from '@/store/slices/cartSlice';
+import { deleteCartItem, modifyCartItem } from '@/store/slices/cartSlice';
+import { AddIcon, MinusIcon } from '@chakra-ui/icons';
+import { CartType } from '@/interface/cart';
 
 type Props = {
-  product: IProduct;
+  product: CartType;
 };
 
 const CartItem = ({ product }: Props) => {
   const dispatch = useAppDispatch();
+  const toast = useToast();
 
   const onDeleteCartItem = () => {
-    Toast({
+    toast({
       title: `장바구니 아이템 삭제`,
       description: `상품이 삭제되었습니다.`,
       position: 'top-right',
@@ -34,6 +38,27 @@ const CartItem = ({ product }: Props) => {
       isClosable: true,
     });
     dispatch(onOpen(product));
+  };
+
+  const onModifyCartItem = (n: number) => {
+    const quantity = product.quantity + n;
+    if (quantity < 0) {
+      return;
+    } else if (quantity > product.maximumPurchases) {
+      toast({
+        title: '최대 구매 수량을 담았습니다.',
+        position: 'top-right',
+        status: 'error',
+        isClosable: true,
+      });
+      return;
+    }
+    dispatch(
+      modifyCartItem({
+        idx: product.idx,
+        quantity,
+      }),
+    );
   };
   return (
     <Card direction={{ base: 'column', sm: 'row' }} w="100%" variant="outline">
@@ -73,6 +98,23 @@ const CartItem = ({ product }: Props) => {
           <Button variant="solid" colorScheme="blue" onClick={onDeleteCartItem}>
             더 보 기
           </Button>
+          <HStack alignSelf="flex-end">
+            <IconButton
+              variant="outline"
+              colorScheme="teal"
+              aria-label="Send email"
+              onClick={() => onModifyCartItem(-1)}
+              icon={<MinusIcon />}
+            />
+            <Text>{product.quantity}</Text>
+            <IconButton
+              variant="outline"
+              colorScheme="teal"
+              aria-label="Send email"
+              onClick={() => onModifyCartItem(1)}
+              icon={<AddIcon />}
+            />
+          </HStack>
         </CardFooter>
       </Stack>
     </Card>

--- a/src/components/CartItem.tsx
+++ b/src/components/CartItem.tsx
@@ -1,0 +1,73 @@
+import {
+  Card,
+  CardBody,
+  Center,
+  Image,
+  Spinner,
+  Stack,
+  Heading,
+  Badge,
+  Text,
+  CardFooter,
+  Button,
+} from '@chakra-ui/react';
+import React from 'react';
+import { IProduct } from '@/interface/product';
+import { useAppDispatch } from '@/store';
+import { onOpen } from '@/store/slices/modalSlice';
+
+type Props = {
+  product: IProduct;
+};
+
+const CartItem = ({ product }: Props) => {
+  const dispatch = useAppDispatch();
+  return (
+    <Card direction={{ base: 'column', sm: 'row' }} w="100%" variant="outline">
+      <Image
+        objectFit="cover"
+        maxW={{ base: '100%', sm: '200px' }}
+        src={product.mainImage}
+        alt={product.name}
+        fallback={
+          <Center w="40%" h="100%">
+            <Spinner />
+          </Center>
+        }
+      />
+      <Stack>
+        <CardBody>
+          <Heading size="md">{product.name}</Heading>
+          <Stack direction="row">
+            <Badge colorScheme="green">
+              {product.price.toLocaleString()} 원
+            </Badge>
+            <Badge colorScheme="purple">{product.spaceCategory}</Badge>
+          </Stack>
+          <Text py="2">{product.description}</Text>
+          <Text py="2">등록번호 : {product.idx}</Text>
+        </CardBody>
+        <CardFooter gap="5px">
+          <Button
+            variant="solid"
+            colorScheme="blue"
+            onClick={() => {
+              alert('준비중');
+            }}
+          >
+            삭제
+          </Button>
+          <Button
+            variant="solid"
+            colorScheme="blue"
+            onClick={() => dispatch(onOpen(product))}
+          >
+            더 보 기
+          </Button>
+        </CardFooter>
+      </Stack>
+    </Card>
+  );
+};
+
+export default CartItem;

--- a/src/components/CartList.tsx
+++ b/src/components/CartList.tsx
@@ -6,22 +6,30 @@ import { Link } from 'react-router-dom';
 
 const CartList = () => {
   const cartList = useAppSelector((state) => state.cart);
+  const totalCost = cartList
+    .reduce((prev, cur) => prev + cur.price * cur.quantity, 0)
+    .toString()
+    .replace(/\B(?=(\d{3})+(?!\d))/g, ',');
 
   return (
     <VStack as="section" minW="500px" p={4}>
+      <Link to="/main">
+        <Button>상품 추가하러 가기</Button>
+      </Link>
       <Heading>장바구니</Heading>
       <Grid as="section" w="100%" p={4}>
         {cartList.length ? (
-          cartList.map((product: CartType) => (
-            <CartItem key={product.idx} product={product} />
-          ))
+          <VStack>
+            {cartList.map((product: CartType) => (
+              <CartItem key={product.idx} product={product} />
+            ))}
+            <Text>총 상품 금액</Text>
+            <Text fontSize="4xl">{totalCost}</Text>
+          </VStack>
         ) : (
           <Center>
             <VStack>
               <Text>장바구니 비어있음</Text>
-              <Link to="/main">
-                <Button>상품 추가하러 가기</Button>
-              </Link>
             </VStack>
           </Center>
         )}

--- a/src/components/CartList.tsx
+++ b/src/components/CartList.tsx
@@ -1,0 +1,21 @@
+import { useAppSelector } from '@/store';
+import { Grid, Heading, VStack } from '@chakra-ui/react';
+import { IProduct } from '@/interface/product';
+import CartItem from './CartItem';
+
+const CartList = () => {
+  const cartList = useAppSelector((state) => state.cart);
+
+  return (
+    <VStack as="section" minW="500px" p={4}>
+      <Heading>장바구니</Heading>
+      <Grid as="section" w="100%" p={4}>
+        {cartList.map((product: IProduct) => (
+          <CartItem key={product.idx} product={product} />
+        ))}
+      </Grid>
+    </VStack>
+  );
+};
+
+export default CartList;

--- a/src/components/CartList.tsx
+++ b/src/components/CartList.tsx
@@ -1,7 +1,8 @@
 import { useAppSelector } from '@/store';
-import { Grid, Heading, VStack } from '@chakra-ui/react';
-import { IProduct } from '@/interface/product';
+import { Button, Center, Grid, Heading, Text, VStack } from '@chakra-ui/react';
 import CartItem from './CartItem';
+import { CartType } from '@/interface/cart';
+import { Link } from 'react-router-dom';
 
 const CartList = () => {
   const cartList = useAppSelector((state) => state.cart);
@@ -10,9 +11,20 @@ const CartList = () => {
     <VStack as="section" minW="500px" p={4}>
       <Heading>장바구니</Heading>
       <Grid as="section" w="100%" p={4}>
-        {cartList.map((product: IProduct) => (
-          <CartItem key={product.idx} product={product} />
-        ))}
+        {cartList.length ? (
+          cartList.map((product: CartType) => (
+            <CartItem key={product.idx} product={product} />
+          ))
+        ) : (
+          <Center>
+            <VStack>
+              <Text>장바구니 비어있음</Text>
+              <Link to="/main">
+                <Button>상품 추가하러 가기</Button>
+              </Link>
+            </VStack>
+          </Center>
+        )}
       </Grid>
     </VStack>
   );

--- a/src/components/Product.tsx
+++ b/src/components/Product.tsx
@@ -16,6 +16,7 @@ import { IProduct } from '@/interface/product';
 import { useAppDispatch, useAppSelector } from '@/store';
 import { onOpen } from '@/store/slices/modalSlice';
 import { addToCart } from '@/store/slices/cartSlice';
+import { CartType } from '@/interface/cart';
 
 const Product = (productData: IProduct) => {
   const dispatch = useAppDispatch();
@@ -23,8 +24,11 @@ const Product = (productData: IProduct) => {
   const toast = useToast();
 
   const handleReservation = (product: IProduct) => {
-    const productLength =
-      cart.filter((item: IProduct) => item.idx === product.idx).length + 1;
+    const filteredCart = cart.filter(
+      (item: CartType) => item.idx === product.idx,
+    );
+
+    const productLength = filteredCart.length ? filteredCart[0].count + 1 : 1;
 
     if (productLength <= Number(product.maximumPurchases)) {
       dispatch(addToCart(product));

--- a/src/components/Product.tsx
+++ b/src/components/Product.tsx
@@ -28,7 +28,9 @@ const Product = (productData: IProduct) => {
       (item: CartType) => item.idx === product.idx,
     );
 
-    const productLength = filteredCart.length ? filteredCart[0].count + 1 : 1;
+    const productLength = filteredCart.length
+      ? filteredCart[0].quantity + 1
+      : 1;
 
     if (productLength <= Number(product.maximumPurchases)) {
       dispatch(addToCart(product));

--- a/src/components/ProductList.tsx
+++ b/src/components/ProductList.tsx
@@ -10,7 +10,6 @@ import {
   Text,
 } from '@chakra-ui/react';
 import { getProducts } from '@/store/slices/productSlice';
-import Product from '@/components/Product';
 import { IProduct } from '@/interface/product';
 import { RootState, useAppDispatch, useAppSelector } from '@/store';
 import {
@@ -18,6 +17,8 @@ import {
   getMaxPrice,
 } from '@/lib/utils/productsHelpers';
 import SpaceTag from './SpaceTag';
+import CartButton from './CartButton';
+import Product from './Product';
 
 const ProductList = () => {
   const dispatch = useAppDispatch();
@@ -64,6 +65,7 @@ const ProductList = () => {
 
   return (
     <VStack as="section" bg="blue.100" w="75%" minW="500px" p={4}>
+      <CartButton />
       <Heading>상품 정보</Heading>
       <VStack as="section" bg="blue.100" w="100%" p={4}>
         <RangeSlider defaultValue={[0, 100]} onChange={onSlidePrice}>

--- a/src/interface/cart.d.ts
+++ b/src/interface/cart.d.ts
@@ -1,0 +1,3 @@
+import { IProduct } from './product';
+
+export type CartType = IProduct & { count: number };

--- a/src/interface/cart.d.ts
+++ b/src/interface/cart.d.ts
@@ -1,3 +1,3 @@
 import { IProduct } from './product';
 
-export type CartType = IProduct & { count: number };
+export type CartType = IProduct & { quantity: number };

--- a/src/pages/Reservations.tsx
+++ b/src/pages/Reservations.tsx
@@ -1,4 +1,16 @@
+import ProductModal from '@/components/ProductModal';
+import { Center } from '@chakra-ui/react';
+import CartList from '../components/CartList';
+
 const Reservations = () => {
-  return <div>Reservations</div>;
+  return (
+    <>
+      <Center as="main" w="100%">
+        <CartList />
+      </Center>
+      <ProductModal />
+    </>
+  );
 };
+
 export default Reservations;

--- a/src/store/slices/cartSlice.ts
+++ b/src/store/slices/cartSlice.ts
@@ -1,18 +1,39 @@
+import { CartType } from '@/interface/cart';
 import { IProduct } from '@/interface/product';
-import { createSlice } from '@reduxjs/toolkit';
+import { createSlice, PayloadAction } from '@reduxjs/toolkit';
 
-const initialState: IProduct[] = [];
+const initialState: CartType[] = [];
 
 const cartSlice = createSlice({
   name: 'cart',
   initialState,
   reducers: {
-    addToCart: (state, action) => {
-      return [...state, action.payload];
+    addToCart: (state, action: PayloadAction<IProduct>) => {
+      const isProductExists = state.some(
+        (product) => product.idx === action.payload.idx,
+      );
+      if (isProductExists) {
+        const mappedCart = state.map((product) => {
+          if (product.idx === action.payload.idx) {
+            return { ...product, count: product.count + 1 };
+          } else {
+            return product;
+          }
+        });
+        return mappedCart;
+      } else {
+        return [...state, { ...action.payload, count: 1 }];
+      }
+    },
+    deleteCartItem: (state, action: PayloadAction<number>) => {
+      const filtered = state.filter(
+        (product) => product.idx !== action.payload,
+      );
+      return filtered;
     },
   },
 });
 
-export const { addToCart } = cartSlice.actions;
+export const { addToCart, deleteCartItem } = cartSlice.actions;
 
 export default cartSlice.reducer;

--- a/src/store/slices/cartSlice.ts
+++ b/src/store/slices/cartSlice.ts
@@ -13,17 +13,30 @@ const cartSlice = createSlice({
         (product) => product.idx === action.payload.idx,
       );
       if (isProductExists) {
-        const mappedCart = state.map((product) => {
+        const modifiedCart = state.map((product) => {
           if (product.idx === action.payload.idx) {
-            return { ...product, count: product.count + 1 };
+            return { ...product, quantity: product.quantity + 1 };
           } else {
             return product;
           }
         });
-        return mappedCart;
+        return modifiedCart;
       } else {
-        return [...state, { ...action.payload, count: 1 }];
+        return [...state, { ...action.payload, quantity: 1 }];
       }
+    },
+    modifyCartItem: (
+      state,
+      action: PayloadAction<{ idx: number; quantity: number }>,
+    ) => {
+      const modifiedCart = state.map((product) => {
+        if (product.idx === action.payload.idx) {
+          return { ...product, quantity: action.payload.quantity };
+        } else {
+          return product;
+        }
+      });
+      return modifiedCart;
     },
     deleteCartItem: (state, action: PayloadAction<number>) => {
       const filtered = state.filter(
@@ -34,6 +47,6 @@ const cartSlice = createSlice({
   },
 });
 
-export const { addToCart, deleteCartItem } = cartSlice.actions;
+export const { addToCart, modifyCartItem, deleteCartItem } = cartSlice.actions;
 
 export default cartSlice.reducer;


### PR DESCRIPTION
## 구현 내용
- [x] 저장한 여행 상품의 리스트 보여주기
- [x] 저장한 여행 상품 삭제
- [x] 여행 상품의 구매 수량 변경
- [x] 장바구니에 있는 여행 상품의 총 결제액 수를 계산하여 표시

## 참고 사항
- 상품리스트에 장바구니로 이동할 수 있는 버튼을 추가했습니다. 장바구니에는 상품리스트로 이동할 수 있는 버튼을 추가했습니다.
- 장바구니 수량 조정을 위해서 IProduct에 quantity 속성을 추가한 `CartType`을 정의했습니다.
- 장바구니에 상품 추가 시 같은 아이템이 여러개 추가되는 것이 아닌, 수량만 증가할 수 있게 상품 추가 로직을 수정하였습니다.
   => 이미 존재하는 상품일 경우 quantity 속성 증가, 존재하지 않을 경우 상품 객체 추가

![add_cart](https://user-images.githubusercontent.com/48446896/224057809-ee683418-9e13-4467-92e9-87e8a8f72619.gif)